### PR TITLE
Server shutdown doesn't yield when saving profiles

### DIFF
--- a/ProfileService.lua
+++ b/ProfileService.lua
@@ -1508,7 +1508,7 @@ game:BindToClose(function()
 		end
 	end
 	-- 2) Yield until all active profile jobs are finished: --
-	while on_close_save_job_count > 0 and ActiveProfileLoadJobs > 0 and ActiveProfileSaveJobs > 0 do
+	while on_close_save_job_count > 0 or ActiveProfileLoadJobs > 0 or ActiveProfileSaveJobs > 0 do
 		RunService.Heartbeat:Wait()
 	end
 	return -- We're done!


### PR DESCRIPTION
The condition that yields in the bindtoclose only yields if the amount of profiles loading>0 AND profiles saving>0. This means that more often than not the BindToClose will not yield at all, causing every profile loaded when the game closes to have a dead session lock.