### PR TITLE
Use RemoveAsync to wipe profiles

### DIFF
--- a/ProfileService.lua
+++ b/ProfileService.lua
@@ -734,12 +734,8 @@ local function StandardProfileUpdateAsyncDataStore(profile_store, profile_key, u
 				wipe_status = true
 				Madwork.HeartbeatWait() -- Simulate API call yield
 			else
-				loaded_data = profile_store._global_data_store:UpdateAsync(profile_key, function()
-					return "PROFILE_WIPED" -- It's impossible to set DataStore keys to nil after they have been set
-				end)
-				if loaded_data == "PROFILE_WIPED" then
-					wipe_status = true
-				end
+				profile_store._global_data_store:RemoveAsync(profile_key)
+				wipe_status = true
 			end
 		end
 	end)


### PR DESCRIPTION
Contrary to the note for the profile wiping implementation, RemoveAsync can set a DataStore key to nil. Changed the implementation to use RemoveAsync instead to represent a true data wipe.

For backwards compatibility reasons I did not remove the bit in the main transform function that sets latest_data to nil if the value is PROFILE_WIPED. That being said, for newer games that wipe profiles the DataStore entry will be completely removed instead of having a value of PROFILE_WIPED.