### PR TITLE
Replace coroutine.wrap references with task.spawn

### DIFF
--- a/Examples/DeveloperProductExample.server.lua
+++ b/Examples/DeveloperProductExample.server.lua
@@ -86,7 +86,7 @@ function PurchaseIdCheckAsync(profile, purchase_id, grant_product_callback) --> 
 				table.remove(local_purchase_ids, 1)
 			end
 			table.insert(local_purchase_ids, purchase_id)
-			coroutine.wrap(grant_product_callback)()
+			task.spawn(grant_product_callback)
 		end
 		
 		-- Waiting until the purchase is confirmed to be saved:
@@ -173,7 +173,7 @@ end
 ----- Initialize -----
 
 for _, player in ipairs(Players:GetPlayers()) do
-	coroutine.wrap(PlayerAdded)(player)
+	task.spawn(PlayerAdded)(player)
 end
 
 MarketplaceService.ProcessReceipt = ProcessReceipt

--- a/Examples/DeveloperProductExample.server.lua
+++ b/Examples/DeveloperProductExample.server.lua
@@ -173,7 +173,7 @@ end
 ----- Initialize -----
 
 for _, player in ipairs(Players:GetPlayers()) do
-	task.spawn(PlayerAdded)(player)
+	task.spawn(PlayerAdded, player)
 end
 
 MarketplaceService.ProcessReceipt = ProcessReceipt

--- a/Examples/PlayerProfileExample.server.lua
+++ b/Examples/PlayerProfileExample.server.lua
@@ -63,7 +63,7 @@ local function PlayerAdded(player)
 	else
 		-- The profile couldn't be loaded possibly due to other
 		--   Roblox servers trying to load this profile at the same time:
-		player:Kick() 
+		player:Kick()
 	end
 end
 
@@ -71,7 +71,7 @@ end
 
 -- In case Players have joined the server earlier than this script ran:
 for _, player in ipairs(Players:GetPlayers()) do
-	coroutine.wrap(PlayerAdded)(player)
+	task.spawn(PlayerAdded, player)
 end
 
 ----- Connections -----

--- a/ProfileTest.server.lua
+++ b/ProfileTest.server.lua
@@ -36,10 +36,10 @@ local ServerScriptService = game:GetService("ServerScriptService")
 local ProfileService
 do
 	local did_yield = true
-	coroutine.wrap(function()
+	task.spawn(function()
 		ProfileService = require(ServerScriptService.ProfileService)
 		did_yield = false
-	end)()
+	end)
 	if did_yield == true then
 		error("[ProfileTest]: ProfileService ModuleScript should not yield when required!")
 	end
@@ -182,7 +182,7 @@ if ProfileTest.TEST_MOCK == true then
 	print("[MOCK]")
 end
 
-coroutine.wrap(function()
+task.spawn(function()
 	
 	print("RUNNING PROFILE TEST")
 	
@@ -665,4 +665,4 @@ coroutine.wrap(function()
 	profile11:Reconcile()
 	TestPass("ProfileService test #11", profile11.Data.Counter == 0 and profile11.Data.Array == false and type(profile11.Data.Dictionary) == "table")
 	
-end)()
+end)

--- a/docs/tutorial/basic_usage.md
+++ b/docs/tutorial/basic_usage.md
@@ -81,7 +81,7 @@ end
 
 -- In case Players have joined the server earlier than this script ran:
 for _, player in ipairs(Players:GetPlayers()) do
-	coroutine.wrap(PlayerAdded)(player)
+	task.spawn(PlayerAdded, player)
 end
 
 ----- Connections -----

--- a/docs/tutorial/developer_products.md
+++ b/docs/tutorial/developer_products.md
@@ -86,7 +86,7 @@ function PurchaseIdCheckAsync(profile, purchase_id, grant_product_callback) --> 
 				table.remove(local_purchase_ids, 1)
 			end
 			table.insert(local_purchase_ids, purchase_id)
-			coroutine.wrap(grant_product_callback)()
+			task.spawn(grant_product_callback)
 		end
 		
 		-- Waiting until the purchase is confirmed to be saved:
@@ -172,7 +172,7 @@ end
 ----- Initialize -----
 
 for _, player in ipairs(Players:GetPlayers()) do
-	coroutine.wrap(PlayerAdded)(player)
+	task.spawn(PlayerAdded, player)
 end
 
 MarketplaceService.ProcessReceipt = ProcessReceipt


### PR DESCRIPTION
Replaces *all* `coroutine.wrap` calls with `task.spawn` calls instead, in `.lua` files and in documentation.