### PR TITLE
Update ProfileService.lua

### DIFF
--- a/ProfileService.lua
+++ b/ProfileService.lua
@@ -2253,21 +2253,18 @@ function ProfileService.GetProfileStore(profile_store_index, profile_template) -
 	}
 	setmetatable(profile_store, ProfileStore)
 
-	local options = Instance.new("DataStoreOptions")
-	options:SetExperimentalFeatures({v2 = true})
-
 	if IsLiveCheckActive == true then
 		profile_store._is_pending = true
 		task.spawn(function()
 			WaitForLiveAccessCheck()
 			if UseMockDataStore == false then
-				profile_store._global_data_store = DataStoreService:GetDataStore(profile_store_name, profile_store_scope, options)
+				profile_store._global_data_store = DataStoreService:GetDataStore(profile_store_name, profile_store_scope)
 			end
 			profile_store._is_pending = false
 		end)
 	else
 		if UseMockDataStore == false then
-			profile_store._global_data_store = DataStoreService:GetDataStore(profile_store_name, profile_store_scope, options)
+			profile_store._global_data_store = DataStoreService:GetDataStore(profile_store_name, profile_store_scope)
 		end
 	end
 


### PR DESCRIPTION
Roblox just released Datastore v2.0
https://devforum.roblox.com/t/datastore-v20-now-officially-launched/1506079

which means the v2 flag is no longer this pull request is to basically remove the options instance entirely as it no longer has any benefit