### PR TITLE
Yield before releasing all profiles in OnClose

### DIFF
--- a/ProfileService.lua
+++ b/ProfileService.lua
@@ -2383,6 +2383,9 @@ task.spawn(function()
 	WaitForLiveAccessCheck()
 	Madwork.ConnectToOnClose(
 		function()
+			-- Allow other OnClose calls to run first:
+			task.wait()
+			
 			ProfileService.ServiceLocked = true
 			-- 1) Release all active profiles: --
 			-- Clone AutoSaveList to a new table because AutoSaveList changes when profiles are released:


### PR DESCRIPTION
Fixes issue mentioned [here.](https://devforum.roblox.com/t/save-your-player-data-with-profileservice-datastore-module/667805/800?u=lucasmz_rbx)

Do some testing just to be sure 👍🏻 