### PR TITLE
Document ProfileService.IsLive()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -43,6 +43,19 @@ Analytics endpoint for cases when DataStore is throwing too many errors and it's
 likely affecting your game really really bad - this could be due to developer errors
 or due to Roblox server problems. Could be used to alert players about data store outages.
 
+### ProfileService.IsLive()
+``` lua
+ProfileService.IsLive() --> [bool] -- (CAN YIELD!!!)
+```
+Returns true if ProfileService is connected to Roblox DataStores
+
+!!! notice
+    `.IsLive()` can only return false in Studio
+
+!!! warning
+    `.IsLive()` can yield while checking if datastores are available in Studio
+
+
 ### ProfileService.GetProfileStore()
 ``` lua
 ProfileService.GetProfileStore(


### PR DESCRIPTION
ProfileService.IsLive() seems to be missing in the API documentation.
It should be documented to help people create their own tests.

I did very basic documentation in my pull request so feel free to improve it and maybe add a warning against using versioning APIs if .IsLive() returns false (however, I chose not to add this as it's mentioned on the versioning API).