### PR TITLE
Create small fast autocomplete for Profile returned by LoadProfileAsync

### DIFF
--- a/ProfileService.lua
+++ b/ProfileService.lua
@@ -2222,7 +2222,7 @@ function ProfileService.GetProfileStore(profile_store_index, profile_template) -
 	local profile_store
 	profile_store = {
 		Mock = {
-			LoadProfileAsync = function(_, profile_key, not_released_handler)
+			LoadProfileAsync = function(_, profile_key, not_released_handler): typeof(profile_store.Mock) & typeof(Profile) & {Data: typeof(profile_template)}
 				return profile_store:LoadProfileAsync(profile_key, not_released_handler, UseMockTag)
 			end,
 			GlobalUpdateProfileAsync = function(_, profile_key, update_handler)


### PR DESCRIPTION
Adds autocomplete for what is returned by ``:LoadProfileAsync``

![image](https://github.com/MadStudioRoblox/ProfileService/assets/12023782/09c5b3f5-7489-45ab-aa2c-94b0fac3737d)


It even keeps values that you add to the table inside of the Autocomplete